### PR TITLE
remove 100% animation since it's kind of distracting on our team screen

### DIFF
--- a/progress/status-page.html.tmpl
+++ b/progress/status-page.html.tmpl
@@ -69,24 +69,6 @@
             box-shadow: 0px 0px var(--progress-container-border-width) var(--progress-container-border-width) var(--complete-color-shadow);
         }
 
-        .shine:after {
-	        content: '';
-            top: 0;
-            transform: translateX(100%);
-            width: 100%;
-            height: 100%;
-            position: absolute;
-            z-index: 1;
-            animation: shine 1s infinite 3s;
-
-            background: linear-gradient(to right, rgba(255,255,255,0) 0%,rgba(255,255,255,0.5) 50%,rgba(128,186,232,0) 99%,rgba(125,185,232,0) 100%);
-        }
-
-        @keyframes shine {
-            0% {transform:translateX(-100%);}
-            100% {transform:translateX(100%);}
-        }
-
         .label {
             text-align: center;
             padding: 5px;
@@ -106,7 +88,7 @@
     <div class="work">
     <span class="label">{{.Title}}</span>
         <div class="progress-bar progress-{{.Progress}}" style="--fill:var(--grad-{{if eq .Progress 100}}100{{else}}{{slice (printf "%d" .Progress) 0 1}}0{{end}})">
-            <div class="fill {{if eq .Progress 100}}shine{{end}}" style="width:{{.Progress}}%">
+            <div class="fill" style="width:{{.Progress}}%">
                 <span class="percentage">{{.Progress}}%</span>
             </div>
         </div>


### PR DESCRIPTION
This removes the flashing animation when the bar reaches 100%. I found it kind of distracting and too eye-catching for a display that's supposed to live in the background. 

What it looks like now:

![image](https://github.com/Rhionin/SanderServer/assets/11298691/625bced5-7a72-4e58-b1a4-25c2e05adcda)
