### PR TITLE
Return an error when no progress entries are found from the HTML

### DIFF
--- a/internal/progress/webProgressChecker.go
+++ b/internal/progress/webProgressChecker.go
@@ -1,6 +1,7 @@
 package progress
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -67,6 +68,11 @@ func parseProgressFromHTML(html string) ([]WorkInProgress, error) {
 		}
 
 		wips = append(wips, WorkInProgress{Title: title, Progress: progress})
+	}
+
+	if len(wips) == 0 {
+		fmt.Println("No progress entries found from HTML:\n", html)
+		return nil, errors.New("no progress entries found")
 	}
 
 	return wips, nil


### PR DESCRIPTION
# What this does
Return an error when no progress entries are found from the HTML (likely happening when there's a network blip)

# Why?
Blips are returning an empty progress list, which is technically different from the progress list before, which ends up triggering the same progress update twice.

![image](https://github.com/user-attachments/assets/8a296415-131f-4c8d-bd99-32b1a5846e2d)

![Screenshot 2025-01-21 at 9 41 39 AM](https://github.com/user-attachments/assets/bf6cdb50-87aa-458b-8bd9-2ab57eb8600a)
